### PR TITLE
Fix int overflow on 32bit OSs

### DIFF
--- a/torrent.go
+++ b/torrent.go
@@ -31,7 +31,7 @@ type (
 		Name          string        `json:"name"`
 		Status        int           `json:"status"`
 		Added         int           `json:"addedDate"`
-		LeftUntilDone int           `json:"leftUntilDone"`
+		LeftUntilDone int64         `json:"leftUntilDone"`
 		Eta           int           `json:"eta"`
 		UploadRatio   float64       `json:"uploadRatio"`
 		RateDownload  int           `json:"rateDownload"`


### PR DESCRIPTION
Original error was:

```
failed to get torrents: json: cannot unmarshal number 72368441637 into Go struct field Torrent.arguments.torrents.leftUntilDone of type int
```

Tested on armv7l.