### PR TITLE
Fix rpc endpoint to avoid "409 Conflict" errors

### DIFF
--- a/transmission.go
+++ b/transmission.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-const endpoint = "/transmission/rpc"
+const endpoint = "/transmission/rpc/"
 
 type (
 	// User to authenticate with Transmission


### PR DESCRIPTION
RPC endpoint needs to end in a "/", since the CSRF checks will fail in transmission if it doesn't, returning a 409 Conflict error instead.