### PR TITLE
Fix LastScrapeTimedOut type

### DIFF
--- a/torrent.go
+++ b/torrent.go
@@ -92,7 +92,7 @@ type (
 		LastScrapeStartTime   int    `json:"lastScrapeStartTime"`
 		LastScrapeSucceeded   bool   `json:"lastScrapeSucceeded"`
 		LastScrapeTime        int    `json:"lastScrapeTime"`
-		LastScrapeTimedOut    int    `json:"lastScrapeTimedOut"`
+		LastScrapeTimedOut    bool   `json:"lastScrapeTimedOut"`
 		LeecherCount          int    `json:"leecherCount"`
 		NextAnnounceTime      int    `json:"nextAnnounceTime"`
 		NextScrapeTime        int    `json:"nextScrapeTime"`


### PR DESCRIPTION
I get a warning says 
```
2020/06/27 22:16:12 failed to get torrents: json: cannot unmarshal bool into Go struct field TrackerStat.arguments.torrents.trackerStats.lastScrapeTimedOut of type int
```
After reading the [transmission rpc-spec.txt](https://github.com/transmission/transmission/blob/master/extras/rpc-spec.txt#L337), I found that the type of `LastScrapeTimedOut` is boolean. So I changed the type and it works good with no warning on the latest transmission.